### PR TITLE
chore: use OpenCraft fork of openedx-django-pyfs

### DIFF
--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -8,7 +8,7 @@ certifi==2022.12.7
     # via requests
 charset-normalizer==3.0.1
     # via requests
-codecov==2.1.12
+codecov==2.1.13
     # via -r requirements/ci.in
 coverage==7.1.0
     # via codecov
@@ -36,7 +36,6 @@ tomli==2.0.1
     # via tox
 tox==3.28.0
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/ci.in
     #   tox-battery
 tox-battery==0.6.1

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -55,7 +55,7 @@ code-annotations==1.3.0
     # via
     #   -r requirements/test.txt
     #   edx-lint
-codecov==2.1.12
+codecov==2.1.13
     # via -r requirements/ci.txt
 coverage[toml]==7.1.0
     # via
@@ -156,7 +156,7 @@ mccabe==0.7.0
     #   pylint
 mock==5.0.1
     # via -r requirements/test.txt
-openedx-django-pyfs==3.2.1
+openedx-django-pyfs @ git+https://github.com/open-craft/django-pyfs.git@opencraft-release/3.5.0-tox-3
     # via -r requirements/test.txt
 packaging==23.0
     # via
@@ -303,7 +303,6 @@ tomlkit==0.11.6
     #   pylint
 tox==3.28.0
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/ci.txt
     #   -r requirements/test.txt
     #   tox-battery

--- a/requirements/django.in
+++ b/requirements/django.in
@@ -6,5 +6,5 @@
 -r base.txt                         # Core XBlock dependencies
 
 Django>=2.2,<3.0
-openedx-django-pyfs>=1.0.5
+git+https://github.com/open-craft/django-pyfs.git@opencraft-release/3.5.0-tox-3#egg=openedx-django-pyfs==3.5.0
 lazy

--- a/requirements/django.txt
+++ b/requirements/django.txt
@@ -36,7 +36,7 @@ lxml==4.9.2
     # via -r requirements/base.txt
 markupsafe==2.1.2
     # via -r requirements/base.txt
-openedx-django-pyfs==3.2.1
+openedx-django-pyfs @ git+https://github.com/open-craft/django-pyfs.git@opencraft-release/3.5.0-tox-3
     # via -r requirements/django.in
 python-dateutil==2.8.2
     # via

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -66,7 +66,7 @@ markupsafe==2.1.2
     #   jinja2
 mock==5.0.1
     # via -r requirements/doc.in
-openedx-django-pyfs==3.2.1
+openedx-django-pyfs @ git+https://github.com/open-craft/django-pyfs.git@opencraft-release/3.5.0-tox-3
     # via -r requirements/django.txt
 packaging==23.0
     # via sphinx
@@ -102,7 +102,6 @@ snowballstemmer==2.2.0
     # via sphinx
 sphinx==5.3.0
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/doc.in
     #   edx-sphinx-theme
 sphinxcontrib-applehelp==1.0.4

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -106,7 +106,7 @@ mccabe==0.7.0
     # via pylint
 mock==5.0.1
     # via -r requirements/test.in
-openedx-django-pyfs==3.2.1
+openedx-django-pyfs @ git+https://github.com/open-craft/django-pyfs.git@opencraft-release/3.5.0-tox-3
     # via -r requirements/django.txt
 packaging==23.0
     # via
@@ -204,9 +204,7 @@ tomli==2.0.1
 tomlkit==0.11.6
     # via pylint
 tox==3.28.0
-    # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
-    #   -r requirements/test.in
+    # via -r requirements/test.in
 typing-extensions==4.4.0
     # via
     #   astroid


### PR DESCRIPTION
## Description

Use openedx-django-pyfs with openedx/django-pyfs#168 and openedx/django-pyfs#169 (backported as open-craft/django-pyfs#2).

## Other information

Private-ref: https://tasks.opencraft.com/browse/BB-8077